### PR TITLE
chore: Update penumbra to 034-aoede

### DIFF
--- a/penumbra/VERSION
+++ b/penumbra/VERSION
@@ -1,2 +1,1 @@
-033-eirene
-
+034-aoede


### PR DESCRIPTION
Automated update for penumbra.

The found in repo version is 033-eirene and the current head is
has been changed to 034-aoede.