### PR TITLE
chore: Update cosmovisor to v0.46.4

### DIFF
--- a/cosmovisor/VERSION
+++ b/cosmovisor/VERSION
@@ -1,1 +1,1 @@
-tools/cosmovisor/v1.4.0
+v0.46.4


### PR DESCRIPTION
Automated update for cosmovisor.

The found in repo version is tools/cosmovisor/v1.4.0 and the current head is
has been changed to v0.46.4.