### PR TITLE
chore: Update penumbra to 035-taygete

### DIFF
--- a/penumbra/VERSION
+++ b/penumbra/VERSION
@@ -1,1 +1,1 @@
-034-aoede
+035-taygete


### PR DESCRIPTION
Automated update for penumbra.

The found in repo version is 034-aoede and the current head is
has been changed to 035-taygete.