### PR TITLE
chore: Update aptos to aptos-node-mainnet_f0c03310a58bd212c04e65def103c5f7862be29f

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-mainnet_3b12b747b53a0dc610b0ea960459bb834a940852
+aptos-node-mainnet_f0c03310a58bd212c04e65def103c5f7862be29f


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-node-mainnet_3b12b747b53a0dc610b0ea960459bb834a940852 and the current head is
has been changed to aptos-node-mainnet_f0c03310a58bd212c04e65def103c5f7862be29f.