### PR TITLE
chore: Update aptos to aptos-node-testnet_80d7b03c630e0066bc12e2a3ba6f3546542bbb8c

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-mainnet_f0c03310a58bd212c04e65def103c5f7862be29f
+aptos-node-testnet_80d7b03c630e0066bc12e2a3ba6f3546542bbb8c


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-node-mainnet_f0c03310a58bd212c04e65def103c5f7862be29f and the current head is
has been changed to aptos-node-testnet_80d7b03c630e0066bc12e2a3ba6f3546542bbb8c.