### PR TITLE
chore: Update aptos to aptos-node-v1.1.0

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-testnet_80d7b03c630e0066bc12e2a3ba6f3546542bbb8c
+aptos-node-v1.1.0


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-node-testnet_80d7b03c630e0066bc12e2a3ba6f3546542bbb8c and the current head is
has been changed to aptos-node-v1.1.0.