### PR TITLE
chore: Update agoric to pismoB

### DIFF
--- a/agoric/VERSION
+++ b/agoric/VERSION
@@ -1,1 +1,1 @@
-pismoA
+pismoB


### PR DESCRIPTION
Automated update for agoric.

The found in repo version is pismoA and the current head is
has been changed to pismoB.