### PR TITLE
chore: Update penumbra to 039-praxidike

### DIFF
--- a/penumbra/VERSION
+++ b/penumbra/VERSION
@@ -1,1 +1,1 @@
-035-taygete
+039-praxidike


### PR DESCRIPTION
Automated update for penumbra.

The found in repo version is 035-taygete and the current head is
has been changed to 039-praxidike.