### PR TITLE
chore: Update aptos to aptos-node-v1.1.1

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-cli-v1.0.3
+aptos-node-v1.1.1


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-cli-v1.0.3 and the current head is
has been changed to aptos-node-v1.1.1.