### PR TITLE
chore: Update penumbra to 040-themisto.1

### DIFF
--- a/penumbra/VERSION
+++ b/penumbra/VERSION
@@ -1,1 +1,1 @@
-035-taygete
+040-themisto.1


### PR DESCRIPTION
Automated update for penumbra.

The found in repo version is 035-taygete and the current head is
has been changed to 040-themisto.1.