### PR TITLE
chore: Update aptos to aptos-node-v1.2.3

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-cli-v1.0.4
+aptos-node-v1.2.3


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-cli-v1.0.4 and the current head is
has been changed to aptos-node-v1.2.3.