### PR TITLE
chore: Update aptos to aptos-node-v1.2.4

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-v1.2.3
+aptos-node-v1.2.4


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-node-v1.2.3 and the current head is
has been changed to aptos-node-v1.2.4.