### PR TITLE
chore: Update agoric to pismoC

### DIFF
--- a/agoric/VERSION
+++ b/agoric/VERSION
@@ -1,1 +1,1 @@
-pismoB
+pismoC


### PR DESCRIPTION
Automated update for agoric.

The found in repo version is pismoB and the current head is
has been changed to pismoC.