### PR TITLE
chore: Update aptos to aptos-cli-v1.0.7

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-v1.2.5
+aptos-cli-v1.0.7


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-node-v1.2.5 and the current head is
has been changed to aptos-cli-v1.0.7.