### PR TITLE
chore: Update aptos to aptos-cli-v1.0.8

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-cli-v1.0.7
+aptos-cli-v1.0.8


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-cli-v1.0.7 and the current head is
has been changed to aptos-cli-v1.0.8.