### PR TITLE
chore: Update penumbra to 049-pasiphae.1

### DIFF
--- a/penumbra/VERSION
+++ b/penumbra/VERSION
@@ -1,1 +1,1 @@
-035-taygete
+049-pasiphae.1


### PR DESCRIPTION
Automated update for penumbra.

The found in repo version is 035-taygete and the current head is
has been changed to 049-pasiphae.1.