### PR TITLE
chore: Update sui to testnet-0.32.1

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-devnet-0.27.0
+testnet-0.32.1


### PR DESCRIPTION
Automated update for sui.

The found in repo version is devnet-0.27.0 and the current head is
has been changed to testnet-0.32.1.