### PR TITLE
chore: Update aptos to aptos-cli-v1.0.12

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-cli-v1.0.11
+aptos-cli-v1.0.12


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-cli-v1.0.11 and the current head is
has been changed to aptos-cli-v1.0.12.