### PR TITLE
chore: Update sui to testnet-v1.2.0

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-devnet-v1.1.0
+testnet-v1.2.0


### PR DESCRIPTION
Automated update for sui.

The found in repo version is devnet-v1.1.0 and the current head is
has been changed to testnet-v1.2.0.