### PR TITLE
chore: Update aptos to aptos-cli-v2.0.0

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-v1.4.1
+aptos-cli-v2.0.0


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-node-v1.4.1 and the current head is
has been changed to aptos-cli-v2.0.0.