### PR TITLE
chore: Update agoric to pismoD

### DIFF
--- a/agoric/VERSION
+++ b/agoric/VERSION
@@ -1,1 +1,1 @@
-pismoC
+pismoD


### PR DESCRIPTION
Automated update for agoric.

The found in repo version is pismoC and the current head is
has been changed to pismoD.